### PR TITLE
Control `apt update`'s `ignore_failure` on adding new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ If you wish to help the `cacher-ng` recipe seed itself, you must now explicitly 
 
 Installs and configures the `unattended-upgrades` package to provide automatic package updates. This can be configured to upgrade all packages or to just install security updates by setting `['apt']['unattended_upgrades']['allowed_origins']`.
 
-To pull just security updates, you'd set `allowed_origins` to something link `["Ubuntu trusty-security"]` (for Ubuntu trusty) or `["Debian wheezy-security"]` (for Debian wheezy). 
+To pull just security updates, you'd set `allowed_origins` to something link `["Ubuntu trusty-security"]` (for Ubuntu trusty) or `["Debian wheezy-security"]` (for Debian wheezy).
 
 
 Attributes
 ----------
 
-### General 
+### General
 * `['apt']['compile_time_update']` - force the default recipe to run `apt-get update` at compile time.
 * `['apt']['periodic_update_min_delay']` - minimum delay (in seconds) beetween two actual executions of `apt-get update` by the `execute[apt-get-update-periodic]` resource, default is '86400' (24 hours)
 
@@ -144,6 +144,7 @@ This LWRP provides an easy way to manage additional APT repositories. Adding a n
 - key: if a `keyserver` is provided, this is assumed to be the fingerprint, otherwise it can be either the URI to the GPG key for the repo, or a cookbook_file.
 - key_proxy: if set, pass the specified proxy via `http-proxy=` to GPG.
 - cookbook: if key should be a cookbook_file, specify a cookbook where the key is located for files/default. Defaults to nil, so it will use the cookbook where the resource is used.
+- ignore_apt_update_failure: set to false if you don't want to ignore `apt update` failing to fetch the repository
 
 #### Examples
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Configures apt and apt services. Ships resources for managing apt repositories'
 issues_url 'https://github.com/chef-cookbooks/apt/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/chef-cookbooks/apt' if respond_to?(:source_url)
-version '2.9.3'
+version '2.9.2'
 
 recipe 'apt::default', 'Runs apt-get update during compile phase and sets up preseed directories'
 recipe 'apt::cacher-ng', 'Set up an apt-cacher-ng caching proxy'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Configures apt and apt services. Ships resources for managing apt repositories'
 issues_url 'https://github.com/chef-cookbooks/apt/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/chef-cookbooks/apt' if respond_to?(:source_url)
-version '2.9.2'
+version '2.9.3'
 
 recipe 'apt::default', 'Runs apt-get update during compile phase and sets up preseed directories'
 recipe 'apt::cacher-ng', 'Set up an apt-cacher-ng caching proxy'

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -194,13 +194,13 @@ action :add do
   end
 
   update_command = "apt-get update -o Dir::Etc::sourcelist='sources.list.d/#{new_resource.name}.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'"
-  if not new_resource.update_ignore_failure
+  if not new_resource.ignore_apt_update_failure
     update_command += "|| { rm /etc/apt/sources.list.d/#{new_resource.name}.list; exit 1; }"
   end
 
   execute 'apt-get update' do
     command update_command
-    ignore_failure new_resource.update_ignore_failure
+    ignore_failure new_resource.ignore_apt_update_failure
     sensitive new_resource.sensitive if respond_to?(:sensitive)
     action :nothing
     notifies :run, 'execute[apt-cache gencaches]', :immediately

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -195,6 +195,7 @@ action :add do
 
   update_command = "apt-get update -o Dir::Etc::sourcelist='sources.list.d/#{new_resource.name}.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'"
   if not new_resource.ignore_apt_update_failure
+    # make sure the source file is deleted, so reprovisioning will try to add the repo again if it failed
     update_command += "|| { rm /etc/apt/sources.list.d/#{new_resource.name}.list; exit 1; }"
   end
 

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -193,9 +193,14 @@ action :add do
     action :nothing
   end
 
+  update_command = "apt-get update -o Dir::Etc::sourcelist='sources.list.d/#{new_resource.name}.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'"
+  if not new_resource.update_ignore_failure
+    update_command += "|| { rm /etc/apt/sources.list.d/#{new_resource.name}.list; exit 1; }"
+  end
+
   execute 'apt-get update' do
-    command "apt-get update -o Dir::Etc::sourcelist='sources.list.d/#{new_resource.name}.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'"
-    ignore_failure true
+    command update_command
+    ignore_failure new_resource.update_ignore_failure
     sensitive new_resource.sensitive if respond_to?(:sensitive)
     action :nothing
     notifies :run, 'execute[apt-cache gencaches]', :immediately

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -39,7 +39,7 @@ state_attrs :arch,
             :trusted,
             :uri,
             :sensitive,
-            :update_ignore_failure
+            :ignore_apt_update_failure
 
 # name of the repo, used for source.list filename
 attribute :repo_name, kind_of: String, name_attribute: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.)+$/]
@@ -59,4 +59,4 @@ attribute :cookbook, kind_of: String, default: nil
 attribute :cache_rebuild, kind_of: [TrueClass, FalseClass], default: true
 # Hide content of the source file, don't show output for commands being run, etc.
 attribute :sensitive, kind_of: [TrueClass, FalseClass], default: false
-attribute :update_ignore_failure, kind_of: [TrueClass, FalseClass], default: true
+attribute :ignore_apt_update_failure, kind_of: [TrueClass, FalseClass], default: true

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -38,7 +38,8 @@ state_attrs :arch,
             :repo_name,
             :trusted,
             :uri,
-            :sensitive
+            :sensitive,
+            :update_ignore_failure
 
 # name of the repo, used for source.list filename
 attribute :repo_name, kind_of: String, name_attribute: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.)+$/]
@@ -58,3 +59,4 @@ attribute :cookbook, kind_of: String, default: nil
 attribute :cache_rebuild, kind_of: [TrueClass, FalseClass], default: true
 # Hide content of the source file, don't show output for commands being run, etc.
 attribute :sensitive, kind_of: [TrueClass, FalseClass], default: false
+attribute :update_ignore_failure, kind_of: [TrueClass, FalseClass], default: true


### PR DESCRIPTION
If you try to add a new apt repository and need to make sure that repository actually exists or get an error, you can now set `ignore_apt_update_failure true` which will cause the provisioning to stop.

For example
```
apt_repository 'failing-repo' do
    uri 'http://ppa.launchpad.net/failing-repo/failing-repo/ubuntu'
    ignore_apt_update_failure true
    components ['main']
    key '12345678'
    keyserver 'keyserver.ubuntu.com'
end
```

The proposed fix, removes the file created for the repo if running `apt update` fails.
Works for both `vagrant up` for a new VM and `vagrant provision` for an existing VM.